### PR TITLE
The Apache init script had an error in the default Apache DocumentRoot.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="N-Squared Software <support@nsquared.nz>"
 ### Config:
 ###
 # set version for s6 overlay
-ARG S6_INIT_SCRIPTS_VERSION="v0.2"
+ARG S6_INIT_SCRIPTS_VERSION="v0.3"
 ARG SERVICES="apache2 openssl"
 
 


### PR DESCRIPTION
The Apache init script had an error in the default Apache DocumentRoot.
This is fixed with release 0.3 of the s6-init scripts.